### PR TITLE
Adopt shared Anthus footer on Anth.us

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mdx-js/mdx": "^2.3.0",
         "@mdx-js/react": "^2.3.0",
         "@parcel/watcher": "^2.3.0",
+        "anthus-footer": "git+https://github.com/AnthusAI/anthus-footer.git#feature/shared-anthus-footer",
         "gatsby": "^5.12.4",
         "gatsby-citation-manager": "^1.0.2",
         "gatsby-plugin-google-fonts": "^1.0.1",
@@ -5455,6 +5456,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/anthus-footer": {
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/AnthusAI/anthus-footer.git#6eb7208544390db110a8593b6a78835d5cbde35d",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
       }
     },
     "node_modules/anymatch": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gatsby-source-filesystem": "^5.12.1",
     "gatsby-transformer-remark": "^6.12.3",
     "gatsby-transformer-sharp": "^5.12.0",
+    "anthus-footer": "git+https://github.com/AnthusAI/anthus-footer.git#feature/shared-anthus-footer",
     "markdown-to-jsx": "^7.3.2",
     "priority-plus": "^1.5.1",
     "prism-react-renderer": "^2.3.1",

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,41 +1,33 @@
 import * as React from "react";
+import AnthusFooter, {
+  defaultBrandLinks,
+  defaultCommunityLinks,
+  getPlatformLinks,
+} from "anthus-footer";
 import { StaticImage } from 'gatsby-plugin-image'
 
-const moreLinks = [
-  { text: "Contact us", url: "https://docs.google.com/forms/d/e/1FAIpQLSdWlt4KpwPSBHzg3o8fikHcfrzxo5rCcV-0-zDt815NZ1tcyg/viewform?usp=sf_link"},
-  { text: "Follow us on GitHub", url: "https://github.com/AnthusAI" },
-  { text: "Connect on LinkedIn", url: "https://www.linkedin.com/in/ryanalynporter/" },
-  { text: "Join us on Discord", url: "https://discord.gg/uStyWraJ2M" }
-]
-
 const Footer = () => {
-
   return (
-    <footer>
-      <div className="fullWidth">
-        <div className="links">
-          {moreLinks.map((link, i) => (
-            <React.Fragment key={link.url}>
-              <a href={`${link.url}`}>{link.text}</a>
-              {i !== moreLinks.length - 1 && <> · </>}
-            </React.Fragment>
-          ))}
-        </div>
-        
-        <div className="contents">
-          <div className="logo">
-            <StaticImage
-              className="logo"
-              alt="Anthus?"
-              src="../images/icon.png"
-              placeholder="BLURRED"
-            />
-          </div>
-        </div>
-      </div>
-    </footer>
+    <AnthusFooter
+      siteId="anthus"
+      productName="Anthus AI Solutions"
+      subtitle="Anthus Platform"
+      description="Anthus builds AI-native systems with durable procedures, operational guardrails, and reusable platform components."
+      communityLinks={defaultCommunityLinks}
+      brandLinks={defaultBrandLinks}
+      platformLinks={getPlatformLinks()}
+      byline="Built by Anthus AI Solutions"
+      logo={
+        <StaticImage
+          className="logo"
+          alt="Anthus"
+          src="../images/icon.png"
+          placeholder="BLURRED"
+          width={96}
+        />
+      }
+    />
   );
-  
 };
 
 export default Footer;


### PR DESCRIPTION
## Summary
- switch the Anth.us footer to the shared `anthus-footer` package
- expose Anthus Platform links from the canonical shared registry
- keep the existing Anthus branding while aligning footer structure with the platform sites

## Test plan
- [x] `npm run build`

Made with [Cursor](https://cursor.com)