### PR TITLE
Add Thrifty tokenmaxxing as a site draft article

### DIFF
--- a/docs/newsroom-handoff/ANTH-c28002/HANDOFF.md
+++ b/docs/newsroom-handoff/ANTH-c28002/HANDOFF.md
@@ -18,4 +18,4 @@ kbs validate
 
 Do **not** edit `project/issues/` by hand. Replay `kanbus-comments.json` only if those comments are missing.
 
-Drafting still paused until Ryan says go.
+Copy draft is in `article.md` (Gemini 3.7 Flash High, editor pass). Raw Gemini: `article.gemini-raw.md`. Do not publish until Ryan says so. Do not create site MDX yet.

--- a/docs/newsroom-handoff/ANTH-c28002/README.md
+++ b/docs/newsroom-handoff/ANTH-c28002/README.md
@@ -1,6 +1,6 @@
 # ANTH-c28002 — consult this first
 
-**Thrifty tokenmaxxing.** Newsroom story. Status: `research`. Copy draft exists (`article.md`). Do not publish until Ryan says so.
+**Thrifty tokenmaxxing.** Newsroom story. Status: `research`. Site draft is `src/site-content/thrifty-tokenmaxxing.mdx` (`state: draft`). Do not flip to published until Ryan says so.
 
 Short id: `ANTH-c28002`  
 Full: `ANTH-c2800247-f8e3-4834-8bf1-a48eb127580e`  

--- a/docs/newsroom-handoff/ANTH-c28002/README.md
+++ b/docs/newsroom-handoff/ANTH-c28002/README.md
@@ -1,6 +1,6 @@
 # ANTH-c28002 — consult this first
 
-**Thrifty tokenmaxxing.** Newsroom story. Status: `research`. Drafting paused until Ryan says go.
+**Thrifty tokenmaxxing.** Newsroom story. Status: `research`. Copy draft exists (`article.md`). Do not publish until Ryan says so.
 
 Short id: `ANTH-c28002`  
 Full: `ANTH-c2800247-f8e3-4834-8bf1-a48eb127580e`  
@@ -30,6 +30,8 @@ Public Anth.us how-to. Analog → Resist temptation → Monitor → Maximize inc
 | File | What it is |
 | --- | --- |
 | `README.md` | This index. Start here. |
+| `article.md` | **Copy draft.** Gemini 3.7 Flash High + editor pass. Newsroom markdown, not site MDX. |
+| `article.gemini-raw.md` | Unedited Gemini output. |
 | `idea.md` | Pitch, spine, split, parked spot tasks. |
 | `assignment.md` | What to write. Must / must not. |
 | `research.md` | Running editorial log + verify table. |

--- a/docs/newsroom-handoff/ANTH-c28002/article.gemini-raw.md
+++ b/docs/newsroom-handoff/ANTH-c28002/article.gemini-raw.md
@@ -1,0 +1,184 @@
+---
+title: "Stop Burning Tokens: The Practical Guide to Context Hygiene and Quota Thrift"
+slug: "stop-burning-tokens"
+date: "2026-09-01"
+copy: "Gemini 3.7 Flash High"
+agent: "bc-c922fab2-56c4-5894-8267-ca3abca6b4b9"
+note: "Raw Gemini output. Editor pass is article.md. Newsroom draft — not site MDX."
+---
+
+AI developer tooling has settled into an uncomfortable commercial pattern: the defaults are designed to burn as much compute as possible before you notice.
+
+Open a new workspace or agent session, and you're dropped straight into the highest-priced flagship model, priority queueing turned on, auto-routing enabled, and every available plugin or context scraper pre-loaded. It feels generous on day one. By day fifteen, your included pool has evaporated, your team has spilled into on-demand metered billing, and nobody can point to a single PR that actually required that firehose of tokens.
+
+The vendor's commercial incentive is simple: maximize token volume and accelerate your trip into overage fees. Your engineering goal is the exact opposite: ship high-quality code while keeping total spend predictable. Our interests aren't aligned here. You have to be your own advocate.
+
+Turning off the priority lane—which I covered in [Never Use Fast](/blog/never-use-fast/)—is just the rate side of the equation. You can dodge the priority multiplier and still get crushed by pure volume. Context is the bill. Every turn in an unmanaged agent thread re-reads everything that came before it. If you don't manage context volume with the same rigor you apply to memory leaks or database queries, your tooling costs will balloon while your agent's actual reasoning degrades.
+
+Controlling that spend doesn't start with an accounting spreadsheet. It starts with three engineering principles, a systematic catalog of context hygiene techniques, and an understanding of how your tools bill your sessions under the hood.
+
+---
+
+## The Three Principles
+
+Managing AI coding costs isn't about pinching pennies on productive work. It's about eliminating waste so you can run more agents on the problems that matter. Everything in this guide flows from three core principles:
+
+1. **Resist temptation.** Default away from frontier overkill and premium latency tiers. Route mechanical work to fast, economical models, and make expensive reasoning models earn their way in. ([Maximize Value, Not Intelligence](/blog/maximize-value-not-intelligence/) walks through the economics of choosing the cheapest model that clears your quality bar).
+2. **Monitor.** You can't trim what you don't measure. Track live token burn and remaining pool balances so you know your burn rate before you hit an overage cliff.
+3. **Maximize included pools only.** Subscription quotas are strictly use-it-or-lose-it. Empty your included buckets every cycle, because their marginal cost is zero and their salvage value is zero. But never let background work spill over into Fast multipliers or on-demand retail meters.
+
+Fast mode and on-demand overages aren't part of your included pool. They're metered retail purchases. The moment an agent crosses that line without human approval, you're paying a premium for compute nobody asked for.
+
+---
+
+## Context Is the Bill
+
+Why does context volume dominate your invoice? Because LLM agent loops operate with quadratic context accumulation.
+
+When an agent runs for 25 turns, it doesn't just read the current instruction. On turn 25, it re-ingests the system prompt, tool definitions, rules files, every command executed, every compiler error, and every intermediate file dump from turns 1 through 24.
+
+The developer community has started documenting the scale of this waste. In an analysis of agent token efficiency, ashu.co observed that effective context in long-running chats often hovers around 16%—meaning roughly 84% of what you're paying to transmit on every turn is conversational sludge, stale error traces, and redundant directory dumps. BSWEN documented an 80/20 rule for AI developer spend: roughly 80% of unmanaged token costs come from the 20% of runaway sessions where context was allowed to compound unchecked.
+
+Earlier community discussions, from the Tokenminning wiki to Continuum's practical advice on right-sizing away from top-tier models for routine tasks, focused on picking cheaper models. But picking a cheaper model only lowers the rate; it doesn't fix the volume multiplier. If an agent carries a 150k token context window into a three-line docstring update, you're still throwing money away.
+
+---
+
+## The 15 Techniques for Context Hygiene and Model Thrift
+
+Here's the complete catalog of techniques to keep agent context lean, fast, and economical.
+
+### 1. Sub-Agent Isolation vs. One Growing Thread
+The single most effective architectural pattern is separating the manager from the workers. Keep your manager thread long-lived for planning and synthesis, but compact that manager thread separately. When it's time to write code, spawn dedicated worker sub-agents that receive a fresh, clean context initialized with only their specific task brief—not the manager's accumulated junk drawer.
+
+Worker isolation saves massive token volume because the worker doesn't re-bill parent history on every edit. But keep an eye on parallelism: running five sub-agents in parallel multiplies active context windows simultaneously. This introduces a quick beat of Jevons paradox: making sub-tasks cheaper and easier encourages you to run far more of them, which can push total token volume higher. That extra work is great if it's soaking up included subscription quota you'd lose anyway; it's a disaster if it's burning on-demand credits or Fast multipliers (a dynamic explored in [The Year Coding Became a Commodity](/blog/ai-coding-cost-collapse-2026/)).
+
+When you aren't delegating to sub-agents, treat `/clear` as a mission reset. Don't let a completed feature ticket linger in the session when you start your next bug fix.
+
+### 2. Context Hygiene Commands
+Use native context commands aggressively. Run `/context` to inspect what's currently resident in the window, and trigger `/compact` to compress conversational history before entering a multi-turn implementation loop. Use session rewind, branch duplication, and summarize-and-restart workflows when a thread wanders. And never paste the same 50-page PDF, API spec, or documentation dump twice in the same conversation.
+
+### 3. Plan vs. Execute Split
+Separate your planning phase from your execution phase. Run your brainstorming, architecture debates, and option exploration in a heavy, throwaway thread. Once the approach is solid, extract the final markdown plan and paste it as the initial brief for a brand new, lightweight execution thread. Your coding agent doesn't need to pay to read the fifteen rejected designs that preceded the final spec.
+
+### 4. Don't Dump the Repo
+Avoid broad repository dumps. Never paste raw 400-file directory trees or run unchecked wildcard file inclusions. Use targeted `@`-mentions for specific files and rely on scoped ripgrep searches. Let the agent discover what it needs through precision lookups rather than force-feeding it your entire codebase upfront.
+
+### 5. Lean Rules, Modular Skills, and MCP Unloading
+Project instructions like `CLAUDE.md`, `.cursorrules`, and Cursor User Rules load on every single turn. Keep them ruthlessly edited, concise, and focused on invariant repository standards. Unload Model Context Protocol (MCP) servers you aren't actively using during the current session. Keep in mind that Cursor child sub-agents inherit *all* active MCP tool declarations from the parent environment, which inflates their base prompt on every turn. Conversely, Claude Code's Explore and Plan phases are optimized to skip redundant rule injections.
+
+### 6. Screenshots and Images Are Token Bombs
+High-resolution images and UI screenshots chew through thousands of tokens per pass. Never paste screenshots "for vibe" or general context. If you must provide visual bug evidence, downscale the image, crop tightly to the affected UI element, and never re-attach the same screenshot on subsequent turns in the same chat.
+
+### 7. Tame the Tool-Result and Compaction Tax
+Tool outputs are a primary source of context pollution. A single unformatted JSON dump, verbose test trace, or browser screenshot embedded in a tool log can inject 20,000 tokens of noise into your history. Explicitly instruct agents to return unified diffs instead of full file contents, filter unit test output to only show failures, and rein in noisy MCP servers that return essay-length responses to basic status queries.
+
+### 8. Don't Retry the Same Failure in the Same Window
+If an agent fails a build or test loop two or three times in a row, stop. The active context is now saturated with misleading error logs and failed repair attempts. Continuing to prompt in that polluted window causes the model to fixate on its own hallucinated workarounds. Kill the session, write a two-sentence summary of why the attempt failed, and start a fresh worker with that constraint added to the brief.
+
+### 9. Prompt Caching and Prefix Stability
+Modern LLM pricing relies heavily on prompt caching discounts, which require byte-identical prefix matching. Keep invariant elements—system instructions, core tool schemas, and base project rules—at the very beginning of the prompt. Place volatile elements—user input, dynamic files, and turn-specific instructions—at the end. Avoid editing or reshuffling rule files mid-session, which instantly invalidates cache hits across your team's active sessions.
+
+### 10. Spec Before Code
+Writing a crisp, ten-line specification or interface contract before asking for code results in a tighter first patch. A clean first patch eliminates five to ten subsequent repair loops full of compiler errors, test failures, and context sludge. A few minutes spent refining the prompt saves thousands of tokens in downstream corrections.
+
+### 11. Model Routing by Phase
+Match the model tier to the cognitive load of the task. Use fast, cost-effective models (Flash, Haiku, Luna, Composer) for mechanical edits, boilerplate generation, lint fixes, and targeted searches. Reserve flagship reasoning models (Opus, Sol) exclusively for complex architectural decisions, thorny debugging triage, or ambiguous system design. Resist the temptation to stay on the flagship tier out of habit.
+
+### 12. Local and Offline Models for Mechanical Chores
+Running local models via tools like Continue and Ollama (using Qwen, DeepSeek-Coder, or Llama) for inline autocomplete, docstring generation, and simple unit tests isn't about claiming "local is always free." Hardware and electricity have real costs. The real value is quota preservation: routing mechanical tasks locally keeps your high-end cloud subscription quotas intact for the heavy reasoning work that actually demands cloud models.
+
+### 13. Batch and Reuse
+Run a single build, test, or compilation pass and ask multiple questions against that output, rather than triggering separate execution passes for each inquiry. If five parallel sub-tasks require information from the same large dependency file, extract a shared summary once rather than having all five workers read the full source independently.
+
+### 14. Output Discipline
+Ask the model for the diff or patch directly, without conversational fluff, narrative preambles, or patronizing summaries. Furthermore, when using models with extended reasoning (chain-of-thought) in products that meter or bill thinking tokens separately, suppress verbose thinking modes on deterministic, mechanical tasks that don't require deep deliberation.
+
+### 15. Session Budgets and Hard Stop Ceilings
+Establish a hard ceiling on session length. When a thread crosses 40k to 50k tokens of accumulated history, reasoning quality drops while per-turn costs spike. Stop before the window turns to sludge: commit the clean diffs, summarize the remaining work, and launch a fresh session to finish the job.
+
+---
+
+## Per-App Quirks and Gotchas (2026 Reality)
+
+Every tool has its own billing quirks, defaults, and hidden toggles. Here is how the landscape looks today:
+
+### Cursor
+- **Auto Mode**: Cursor's Auto mode is an automated router that bills at the list price of whichever model it chooses—it is not a discounted rate. Don't leave Auto on as a cost-saving strategy.
+- **Fast Multiplier**: Fast mode is a separate priority multiplier. Watch out: the product has a habit of silently flipping Fast back on across updates or new sessions. Check your model chip before launching long async agent runs. (Check your product's specific multiplier; while Composer Fast was documented at 6× Standard in our earlier checks, multipliers shift frequently).
+- **Max Mode**: Cursor offers a 200k vs. 800k context toggle. Don't leave 800k enabled when you're editing a standard 200-line module.
+- **Sub-Agent Mechanics**: Cursor sub-agents receive parent-written briefs rather than the raw chat transcript, but they inherit *all* configured MCP servers from the host environment, which inflates base token consumption.
+- **Monitoring**: Check the Usage page in your Cursor dashboard regularly. There is no first-party leftover CLI, but community tools like `CodexBar` can track your quota status. Note that Cursor's pricing FAQ indicates Privacy Mode may disable certain extra usage telemetry.
+
+### Codex
+- **Pool Structure**: Operates on a dual pool system: a rolling 5-hour refresh plus a weekly allotment, with extra credits available for overages.
+- **Tiers**: Distinguishes between Fast mode and Extra Extra usage tiers.
+- **Context Forking**: The `fork_turns` flag exists for branching context, though its CLI default is undocumented. Avoid deep forks when a fresh brief will do.
+- **Input Costs**: Vision and image inputs remain exceptionally expensive.
+- **Monitoring**: Use community utilities like `natefik/codexbar` or `pskl/codexbar` to inspect live pool balances.
+
+### Claude Code
+- **Billing**: Extra Usage triggers automatically once your included weekly tier is exhausted.
+- **Hygiene Commands**: Native support for `/context` and `/compact`.
+- **Rule Loading**: `CLAUDE.md` is re-injected every turn, though the specialized Explore and Plan modes are optimized to skip redundant rule injections.
+- **Forking**: Running `fork` copies the entire parent conversation history; spawning standard non-fork workers passes brief-only context.
+- **Modes**: Effort and fast modes are controlled via dedicated product flags.
+- **Monitoring**: `ccusage` is the standard tool for parsing local logs and inspecting historical token spend.
+
+### Antigravity (Google AI)
+- **Quotas**: Features a 5-hour rolling pool alongside a weekly limit. Standard tiers include default Fast quota, with Pro, Ultra, and Max tiers expanding capacity.
+- **Model Strategy**: Offers Auto vs. Manual routing. Switch to Manual if you want to prevent the system from automatically escalating mechanical tasks to expensive flagship tiers.
+- **Workflow**: Generate an Implementation Plan artifact first, then spin up targeted task agents to execute individual steps.
+- **Billing**: Pay attention to preview model designations and prompt-only vs. credit billing.
+
+### Grok Bot
+- **Model Selection**: Offers Grok 4 Fast vs. Grok 4.1, along with SuperGrok vs. Heavy reasoning tiers.
+- **Billing**: Treats the context window as a billed geometric shape. On paid Cursor plans, included Grok Bot usage resets weekly, with overages spilling directly into on-demand billing.
+
+### The Auto-Discount Exception: GitHub Copilot
+While Cursor and Claude Code route Auto models at full list price, GitHub Copilot remains an exception: its documentation still lists a 10% discount when using its automated model selector. Keep that distinction in mind if you work across multiple IDE ecosystems.
+
+---
+
+## Tooling and Monitoring: What to Run
+
+Don't rely on guesswork or raw invoices to track token consumption. Follow established open-source tools with active community support:
+
+- **CodexBar** (~21k GitHub stars): The standard live menubar and CLI tool for monitoring real-time remaining quota across multiple AI providers (Cursor, Codex, Claude, and Antigravity). It shows you exactly how much included capacity remains in your 5-hour and weekly pools.
+- **ccusage** (~18k stars, ~85k weekly npm downloads): The essential tool for inspecting Claude Code logs, breaking down token burn by session, model, and caching efficiency.
+
+Skip tiny, unmaintained zero-star wrapper scripts. Stick to tools that accurately parse official logs and API counters.
+
+---
+
+## Spot Tasks: The Unused Quota Opportunity
+
+Subscription quotas are structured with rolling 5-hour windows and weekly resets. If you have 40% of your pool remaining thirty minutes before a reset, that compute simply vanishes.
+
+Unused included quota is spare capacity, exactly like AWS spot instances.
+
+Interactive development—where an engineer is actively waiting for an answer—is on-demand compute. Deferrable, interruptible chores—backfilling unit tests, syncing documentation, checking for dead code, scanning for dependency drift, or exploring refactoring paths—are spot tasks.
+
+In an ideal workflow, background spot tasks would automatically spin up to consume leftover quota right before a reset, and immediately yield (preempt) the moment a developer sends an interactive prompt. Today, this is a near-miss: tools like `afterburner`, `token-burn`, and community leftover monitors attempt to track this space, but native IDE schedulers are still strictly time-based (cron) rather than leftover-aware.
+
+Until first-party tools support true spot scheduling, you can capture that value manually: when your monitor shows spare quota nearing a reset window, queue up non-urgent maintenance briefs in fresh worker threads. Just ensure those tasks are killed before they spill into on-demand billing.
+
+---
+
+## Be Your Own Advocate
+
+Tooling providers will continue to make priority lanes, heavy models, and auto-expanding context windows the default. That makes sense for their balance sheets. But our job is to deliver reliable software efficiently.
+
+Take control of your environment:
+- Turn off Fast mode unless someone is actively waiting on the output.
+- Keep your system prompts and rules files lean.
+- Isolate your workers with fresh briefs instead of dragging around 100k tokens of conversational baggage.
+- Monitor your pools with `CodexBar` and `ccusage`, and empty your included buckets before they reset.
+
+Context hygiene is just engineering discipline applied to agent workflows. Manage your context with the same care you give your codebase, and you'll get faster, sharper results at a fraction of the cost.
+
+---
+
+### Companion Pieces
+- [Never Use Fast](/blog/never-use-fast/) — Why priority latency lanes are almost never worth the multiplier for asynchronous agent work.
+- [Maximize Value, Not Intelligence](/blog/maximize-value-not-intelligence/) — The economic framework for routing work to the cheapest model that clears your quality threshold.
+- [The Year Coding Became a Commodity](/blog/ai-coding-cost-collapse-2026/) — How falling capability costs and expanding agent loops multiply to change software engineering economics.

--- a/docs/newsroom-handoff/ANTH-c28002/article.md
+++ b/docs/newsroom-handoff/ANTH-c28002/article.md
@@ -1,0 +1,184 @@
+---
+title: "Thrifty tokenmaxxing"
+suggested_title: "Stop Burning Tokens: The Practical Guide to Context Hygiene and Quota Thrift"
+slug: "thrifty-tokenmaxxing"
+date: "2026-09-01"
+authors:
+  - author: <a href="/ryan">Ryan Porter</a>
+tags:
+  - articles
+copy: "Gemini 3.7 Flash High (bc-c922fab2-56c4-5894-8267-ca3abca6b4b9)"
+editor: "Cloud agent bc-01a05cc5 — restored analog, firsthand Fast, merged context-techniques.md items Gemini missed, cut invented session-size numbers"
+state: draft
+note: "Newsroom draft — not site MDX. Do not publish until Ryan says so. Recheck live quota numbers, model ids, and Fast multipliers before ship."
+---
+
+They offer you Fast — or whatever the new premium default is this month — like a dealer sliding you a free first hit. Except it isn't free.
+
+Open a new workspace and you're already on the flagship, priority queueing on, Auto routing, every plugin loaded. It feels generous on day one. By day fifteen the included pool is gone, you're on metered overage, and nobody can point to a PR that needed that firehose.
+
+Their incentive is simple: more tokens, more-expensive tokens, faster trip into overage. Yours is the opposite: ship the work on a watched budget. Interests aren't aligned. They don't want you to notice. You are your own advocate. Just say no.
+
+That's the rate trick. I wrote the tax table in [Never Use Fast](/blog/never-use-fast/). Don't reprint it here. You can dodge the multiplier and still get crushed by volume. Context is the bill. Every turn re-reads the pile. Leave junk in the window and you pay for it again, and again.
+
+This isn't a spreadsheet piece. It's three principles, a catalog of volume moves, and the per-app gotchas that fight you while you work.
+
+## Three principles
+
+Managing coding-agent cost isn't about pinching pennies on work that matters. It's about cutting waste so the included pool covers more of the work that does.
+
+1. **Resist temptation.** Default off the flagship and the premium latency lane. Make the expensive model earn the turn. [Maximize Value, Not Intelligence](/blog/maximize-value-not-intelligence/) is the buying philosophy; this piece is the fight plus the settings.
+2. **Monitor.** You can't trim what you don't measure. Live leftover and historical burn are different jobs. Follow both.
+3. **Maximize included pools only.** Subscription buckets are use-it-or-lose-it. Empty them before they reset. Fast and on-demand are not that pool. They're retail.
+
+I turn Fast off. Cursor turns it back on. I'm working async on purpose — nobody is waiting on the stream — and the product still re-offers the hit. That's Resist as a live fight, not a one-time click. I said it doubles the bill; last time we measured, Composer Fast was 6× Standard. Check your product's multiplier. Then turn it off again.
+
+## Context is the bill
+
+Pick a cheaper model and you only lowered the rate. The volume multiplier is the window.
+
+On turn twenty-five the agent isn't reading your latest instruction. It's re-ingesting the system prompt, the tool list, the rules files, every command, every compiler error, and every intermediate dump from turns one through twenty-four. Context itself grows roughly linearly. The *bill* compounds: each turn re-sends the whole pile.
+
+Other people's thrifty-coding writing already says this. ashu.co put effective context in long chats around 16% — meaning most of what you're paying to transmit is sludge. BSWEN's 80/20 is the same shape: unmanaged runaway sessions dominate spend. The Tokenminning wiki and Continuum's "stop putting Opus on routine work" crowd already cover Resist-flagship. Maximize-the-included-pool is the thinner public lane. What's below is the volume catalog.
+
+Shrink the pile.
+
+## The catalog
+
+Record everything. Proofreading can cut later.
+
+### 1. Manager holds the long thread. Workers start fresh.
+
+This is the architecture, not a slogan.
+
+Keep one manager thread for planning and synthesis. Compact *that* thread separately. When it's time to write code, spawn a worker with a fresh context that contains only the brief — not the manager's junk drawer. Isolation can save because the worker doesn't re-bill parent history on every edit.
+
+Caveat: clean chat isn't thin context. Cursor children inherit all MCP. Claude loads `CLAUDE.md` except in Explore/Plan. Claude `fork` copies the junk drawer; non-fork is brief-only. Pin cheap models on workers. Unset inheritance is expensive fan-out.
+
+Parallelism is the other knob. Five workers means five windows at once. Then one beat of Jevons: cheaper tasks → more tasks → the total can rise. Extra work is fine if it's included quota you'd lose anyway. It isn't fine if it burns on-demand or Fast. That's the catch in [The Year Coding Became a Commodity](/blog/ai-coding-cost-collapse-2026/). Don't retell it here.
+
+`/clear` is the mission reset. It is not competing with sub-agents. Clear when the *job* changes. Compact when you're still on the same job and the history is getting loud.
+
+### 2. `/clear` vs `/compact`
+
+Clear between jobs (free reset). Compact inside one long job (summarize and continue). Don't compact junk you should have cleared. Use `/context` when the product has it. Rewind, duplicate, summarize-and-restart when a thread wanders. Don't paste the same PDF twice.
+
+### 3. Plan in a heavy thread. Execute in a thin one.
+
+Brainstorm and argue architecture in a throwaway window. Extract the plan. Paste that plan as the brief for a new execution thread. The coder doesn't need the fifteen rejected designs.
+
+### 4. Name the file. Don't dump the repo.
+
+A bare path isn't `@file`. `@` injects the whole file; a path lets the agent read what it needs. Don't paste a 400-file tree. Don't grep the repo blind. Point at symbols and paths. Exploration is input tokens.
+
+### 5. Keep always-on rules thin. Unload MCP you aren't using.
+
+`CLAUDE.md`, Cursor User Rules, Copilot instructions: per-message tax, not a one-time setup. Keep them short. Path-scope rules when the app allows it. Tool lists are standing context. Turn MCP off until you need it. Prefer a short CLI call over an always-connected server.
+
+### 6. Images are token bombs.
+
+Don't paste a screenshot "for vibe." Downscale. Crop. Don't re-attach. Codex vision is expensive. If the bug is in the pixels, send the pixels once.
+
+### 7. Tame the tool-result tax.
+
+Verbose traces, giant JSON, screenshots in the tool log: that's how windows die. Ask for diffs, not full files. Keep test failures, drop passing noise. Rein in MCP that returns novels.
+
+### 8. Two strikes, then clear.
+
+If the agent fails the same build twice, stop arguing in the junk drawer. Write a two-sentence constraint. New worker. Same window after a few loops is how models fixate on their own leftover mistakes.
+
+### 9. Don't switch models mid-chat. Keep the prefix stable.
+
+Cache discounts want a byte-identical prefix. Invariant stuff first: system, tools, rules. Volatile user last. Don't reshuffle rules mid-session. Don't switch tiers in the same thread — that's a cache miss. New chat if you change models.
+
+### 10. Don't resume a stale session.
+
+Idle long enough and some products re-bill the prefix. `/clear` and start. Don't wake last Tuesday's agent to fix a one-line typo.
+
+### 11. Spec before code.
+
+A tight first patch beats five repair loops. Write the interface contract. Then ask for the diff.
+
+### 12. Drop finished files. One agent, one job, one branch.
+
+When the refactor of `foo.ts` is done, drop it. Don't keep the whole tour in context. Split when the shape of the work changes. One agent, one checkout: worktrees for parallel agents. Don't share a dirty tree.
+
+### 13. Pin worker models. Route by phase.
+
+Mechanical edits, lint, search: cheap/fast models (Haiku, Luna, Composer, Flash). Hard reasoning: flagship, and only then. Resist staying on Opus or Sol out of habit. Pin workers explicitly. Sub-agents that inherit the parent will spend like the parent.
+
+### 14. Local for mechanical work. Cap unattended runs.
+
+Continue + Ollama for autocomplete and docstrings isn't "local is always cheaper." Hardware isn't free. It *is* quota preservation: keep the included cloud pool for work that needs the cloud. On unattended CLI, set a volume fuse (`--max-ai-credits` and friends). That's not Fast. That's a kill switch.
+
+### 15. Batch, reuse, ask for the patch, stop before sludge.
+
+One compile, many questions. Don't re-read the same file in five chats — summarize once, share the summary. Ask for the diff, not the essay. Suppress billed thinking on mechanical tasks. Stop before the window is sludge: commit, summarize, new session. Don't wait for the product to degrade the answers and raise the per-turn cost at the same time.
+
+## Per-app notes (recheck before publish)
+
+### Cursor
+
+Auto is a router at the routed model's list price. It is not a discount. Don't leave Auto on as a savings strategy in 2026.
+
+Fast is a separate multiplier. The product flips it back on while I work async. Check the chip before you launch a long agent. Privacy Mode, per Cursor's pricing FAQ, may disable some extra-usage paths — verify live.
+
+Max Mode is 200k vs 800k. Don't leave 800k on for a 200-line module.
+
+Sub-agents get a parent-written brief, not the chat. They inherit all MCP. Best-of-N and parallel agents multiply windows. Pin `fast=false` on children when you can. New chat per task. Watch `.cursor/rules` size. `.cursorignore` exists; use it.
+
+Usage page in the dashboard. No first-party leftover CLI. CodexBar covers Cursor leftover.
+
+### Codex
+
+Rolling 5-hour pool plus weekly, then extra credits. Fast vs Extra Extra usage are different meters. Name `gpt-5.6-luna` when you want Luna; bare `gpt-5.6` has been routing to Sol — recheck before ship. `fork_turns` exists; the CLI default is undocumented, so this draft will not invent a number. Prefer a fresh brief over a deep fork. Image inputs are expensive. Azure provisioned vs pay-go is a different bill.
+
+Live leftover: CodexBar (`steipete/CodexBar`). Don't treat tiny one-off bars as the community.
+
+### Claude Code
+
+Included weekly, then Extra Usage. `/context` and `/compact` are first-party. `/clear` between jobs. `CLAUDE.md` every turn except Explore/Plan. Fork copies parent; non-fork is brief-only. Effort / fast mode is a product flag, not "the included pool." Pin cheap models on sub-agents. Hooks that keep test failures and drop passing noise. `isolation: worktree` when you're paralleling. `ccusage` for historical logs.
+
+### Antigravity
+
+5-hour plus weekly. Default Fast quota on some tiers; Pro/Ultra/Max expand capacity. Separate Gemini vs Claude/GPT pools on Google AI Pro — exhaust both, don't leave one idle. Model Strategy Auto vs Manual: Manual if you need to stay off expensive models. Implementation Plan first, then task agents. Artifacts vs chat. Preview-model and prompt-only vs credits: read the meter you're actually on.
+
+### Grok Bot
+
+Grok 4 Fast vs Grok 4.1. SuperGrok vs Heavy. Context window is a billed shape — don't treat max context as free headroom. On paid Cursor plans, Grok Bot has had its own weekly pool; unused dies. Recheck before publish. Don't invent X.ai seat prices here. Product review lives on another card.
+
+### Copilot, only as the Auto exception
+
+GitHub Copilot's docs still list a 10% Auto discount. Cursor and Claude Auto bill at list. `/new` vs `/compact`. Session credit caps exist. Not the fifth how-to app in this piece — just don't copy Copilot's Auto advice onto Cursor.
+
+## Monitor
+
+Two jobs. Don't mix them.
+
+**CodexBar** (~21k GitHub stars): live leftover. Menu bar plus CLI. Codex, Claude, Cursor, Copilot, Grok, Antigravity. Reset clocks and remaining percent. This is the one that chases vendor API changes.
+
+**ccusage** (~18k stars, ~85k npm/week): historical logs. What did this week cost, by session and model. Not live remaining-%.
+
+Optional if you want both in a TUI: tokscale. Skip tiny glue (`aiuse`, `aiquota`). Real, and not the community.
+
+## Spot tasks (near-miss)
+
+Unused included quota is spare capacity, like AWS spot instances. Interactive work — you're waiting on the answer — is on-demand. Deferrable, interruptible chores (backfill tests, docs, dead-code scans, dependency drift) can fill leftover before the reset, then preempt when you need the pool.
+
+That dispatcher is almost a thing. It is not a product. `token-burn` and leftover bars watch. Native schedulers are still time-based, not leftover-based. Until something actually preempts, do it by hand: CodexBar shows spare quota near a reset, you queue a maintenance brief in a fresh worker, and you kill it before it spills into on-demand.
+
+Don't build Chattic or Kanbus from this article. That's a later card.
+
+## Be your own advocate
+
+Vendors will keep making the premium default feel like a gift. Just say no.
+
+Turn Fast off, and check that it stayed off. Pin cheap workers. Compact the manager; give each worker only the brief. Follow CodexBar and ccusage. Empty included buckets before they die. Spend leftover on interruptible chores, not on a latency lane nobody asked for.
+
+Context hygiene is ordinary engineering applied to agent windows. Manage the pile the way you already manage memory leaks. The models get sharper. The bill gets quieter.
+
+## Companion pieces
+
+- [Never Use Fast](/blog/never-use-fast/) — the latency surcharge. Tax table lives there.
+- [Maximize Value, Not Intelligence](/blog/maximize-value-not-intelligence/) — cheapest model that clears the bar.
+- [The Year Coding Became a Commodity](/blog/ai-coding-cost-collapse-2026/) — Jevons and the market. One beat, not a retell.

--- a/docs/newsroom-handoff/ANTH-c28002/research.md
+++ b/docs/newsroom-handoff/ANTH-c28002/research.md
@@ -1,6 +1,8 @@
 # Research notes
 
-Starter pack, 2026-09-01. Not a finished report. Drafting paused until Ryan says go.
+Starter pack, 2026-09-01. Not a finished report.
+
+**Copy (2026-09-01):** Ryan: use Gemini (GLM 5.2 unavailable). Draft in `article.md`. Copy model: Gemini 3.7 Flash High (`bc-c922fab2-56c4-5894-8267-ca3abca6b4b9`). Editor restored the first-hit analog, firsthand Fast toggle, and the `context-techniques.md` items Gemini missed; cut invented 40k/20k session numbers. Working title kept. Do not publish until Ryan says so.
 
 **Other agents: start at `README.md`.** File index and Ryan’s locked calls are there.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ryan asked for this as an **actual site draft**, not newsroom-only markdown, and to merge it into `develop`.

## Site draft

- `src/site-content/thrifty-tokenmaxxing.mdx` — `state: draft` (DRAFT overlay, not on the public blog index)
- Cover: `src/site-content/images/thrifty-tokenmaxxing.png` (1200×630)
- Landed on **anthus-site-content `main`** (`4cbc6c5`) so the content deploy can pick it up
- Anth.us submodule pointer updated to that SHA

The page will be `/blog/thrifty-tokenmaxxing/` with a draft overlay. Flip `state: published` only when Ryan says so.

Working title, first-hit analog, firsthand Fast toggle, techniques catalog, per-app notes, CodexBar + ccusage, spot tasks as a near-miss. Newsroom packet remains in `docs/newsroom-handoff/ANTH-c28002/` for research trail.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05cc5-ef1d-7a0c-aefb-544e5f077187?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05cc5-ef1d-7a0c-aefb-544e5f077187&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

