### PR TITLE
Fix stale deploy wiping thrifty-tokenmaxxing from S3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Overlapping s3 sync --delete races delete pages that a newer deploy just uploaded.
+concurrency:
+  group: deploy-s3-cloudfront
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: read


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A stale anthus-site-content deploy finished *after* the Anth.us submodule bump, ran `aws s3 sync --delete`, and removed `/blog/thrifty-tokenmaxxing/` from S3. Gatsby had already built and uploaded the page.

This PR:
- Adds a workflow `concurrency` group so overlapping production deploys cancel instead of racing
- Bumps `src/site-content` to the SHA that still contains `thrifty-tokenmaxxing.mdx` (`state: draft`)

Merging to `main` is the fast (~3–4 min) restore. Also landing the same lock on the content repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05cc5-ef1d-7a0c-aefb-544e5f077187?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05cc5-ef1d-7a0c-aefb-544e5f077187&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

