### PR TITLE
Pin sanitize-html so main can deploy again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8044,12 +8044,6 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
-    "node_modules/dayjs": {
-      "version": "1.11.23",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
-      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
-      "license": "MIT"
-    },
     "node_modules/debug": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
@@ -11729,6 +11723,25 @@
       "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==",
       "license": "ISC"
     },
+    "node_modules/gatsby-transformer-remark/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/gatsby-transformer-remark/node_modules/is-alphabetical": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
@@ -12104,6 +12117,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/gatsby-transformer-remark/node_modules/sanitize-html": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
+      "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
       }
     },
     "node_modules/gatsby-transformer-remark/node_modules/trough": {
@@ -15026,15 +15053,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/launder": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
-      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
-      "license": "MIT",
-      "dependencies": {
-        "dayjs": "^1.11.7"
       }
     },
     "node_modules/levn": {
@@ -22248,137 +22266,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
-    },
-    "node_modules/sanitize-html": {
-      "version": "2.17.7",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.7.tgz",
-      "integrity": "sha512-PGtEkc9cbnedU3s9TmzDbpsZ8w086g/0Q8k8/oIO1NLNU3i5k9yn835CrjJSajp1KMmkisbO1qPXxNKO3welAg==",
-      "license": "MIT",
-      "dependencies": {
-        "deepmerge": "^4.2.2",
-        "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^12.0.0",
-        "is-plain-object": "^5.0.0",
-        "launder": "^1.7.1",
-        "parse-srcset": "^1.0.2",
-        "postcss": "^8.3.11"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/dom-serializer": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
-      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^3.0.0",
-        "domhandler": "^6.0.0",
-        "entities": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/domelementtype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
-      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/domhandler": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
-      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/domutils": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
-      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^3.0.0",
-        "domelementtype": "^3.0.0",
-        "domhandler": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/htmlparser2": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-12.0.0.tgz",
-      "integrity": "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^3.0.0",
-        "domhandler": "^6.0.0",
-        "domutils": "^4.0.2",
-        "entities": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      }
     },
     "node_modules/sass": {
       "version": "1.77.8",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "react-server-dom-webpack@0.0.0-experimental-c8b778b7f-20220825": {
       "react": "^18.2.0"
     },
-    "msgpackr": "^1.11.2"
+    "msgpackr": "^1.11.2",
+    "sanitize-html": "2.13.0"
   },
   "keywords": [
     "gatsby"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Dependabot merged sanitize-html 2.17.7 (#25). That version depends on htmlparser2 v12 (ESM). Gatsby still `require()`s it through `gatsby-transformer-remark`, so `gatsby build` dies with `ERR_REQUIRE_ESM`.

The postcss bump deploy (#28) failed for that reason. The live site is still the previous successful deploy; `main` cannot ship until this is pinned.

This adds an npm override for `sanitize-html@2.13.0` (last known good, CJS htmlparser2).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05cc5-ef1d-7a0c-aefb-544e5f077187?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05cc5-ef1d-7a0c-aefb-544e5f077187&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

