### PR TITLE
Add permissive robots.txt so production stops 403ing crawlers

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

https://anth.us/robots.txt currently returns HTTP 403 Access Denied from S3/CloudFront because no `robots.txt` object exists. Missing keys on this bucket return Access Denied (not 404). Twitterbot and other crawlers treat a `robots.txt` 403 like a block. We do not want any robots exclusion for the published site.

## Solution

Add `static/robots.txt` so Gatsby copies it to the site root on build:

```
User-agent: *
Allow: /
```

No Sitemap line — there is no sitemap on production yet. Draft `noindex` in `blog-post.jsx` is unchanged.

## Details

- One-file change on a short-lived branch from current `main`.
- Does not merge `develop` into `main`.
- Does not edit the site-content submodule.

**Verify after deploy:**

```bash
curl -sSIL https://anth.us/robots.txt
```

Should be HTTP 200 with `Allow: /`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3c8b5fc-af41-41da-90e9-7f3ee7a5988a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3c8b5fc-af41-41da-90e9-7f3ee7a5988a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

