### PR TITLE
Emit og:image and summary_large_image for post social previews

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -69,7 +69,11 @@ function Seo({ description, title, children, image, imageURL }) {
       <meta property="og:title" content={title} />
       <meta property="og:description" content={metaDescription} />
       <meta property="og:type" content="website" />
-      <meta name="twitter:card" content="summary" />
+      {imageURL && <meta property="og:image" content={imageURL} />}
+      <meta
+        name="twitter:card"
+        content={imageURL ? "summary_large_image" : "summary"}
+      />
       <meta name="twitter:creator" content={site.siteMetadata?.author || ``} />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={metaDescription} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`src/components/seo.js` always emits `twitter:card=summary` and never emits `og:image`. Production posts such as https://anth.us/blog/looking-around-is-enough/ have `twitter:image` but a summary card and no `og:image`. X/Twitter drops large images on `summary`, and scrapers need `og:image`.

## Solution

When `imageURL` is present, emit `og:image` and set `twitter:card` to `summary_large_image`. When it is missing, keep `twitter:card=summary` and skip `og:image`. Existing `twitter:image`, `og:title`, `og:description`, and draft noindex behavior are unchanged.

## Details

- Minimal change in `src/components/seo.js` only.
- Blog posts already pass an absolute cover URL into `imageURL` from `blog-post.jsx`.
- **Verify after deploy:** a post with a cover should have `og:image` as an absolute URL and `twitter:card=summary_large_image`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d10ebf31-6af2-4eb6-8eac-f60a9d00e071?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d10ebf31-6af2-4eb6-8eac-f60a9d00e071&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

