### PR TITLE
Show post title and excerpt on short-post cards

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -423,7 +423,15 @@ const IndexPage = () => {
                 {/* Was a <p> wrapping <div>s, which is invalid nesting and threw a
                     validateDOMNesting warning on every render. */}
                 <div>
-                  <div>{node.frontmatter.excerpt}</div>
+                  <div className={styles.listItemTitle}>
+                    {node.frontmatter.title}
+                  </div>
+                  {node.frontmatter.excerpt?.trim() !==
+                    node.frontmatter.title?.trim() && (
+                    <div className={styles.listItemDescription}>
+                      {node.frontmatter.excerpt}
+                    </div>
+                  )}
                   <div className={styles.listItemRight}>
                     <div className={styles.listItemDate}>
                       {formatDate(node.frontmatter.date)}
@@ -435,7 +443,7 @@ const IndexPage = () => {
                 </div>
                 <GatsbyImage
                   image={getImage(node.frontmatter.preview_image)}
-                  alt={node.frontmatter.excerpt}
+                  alt={node.frontmatter.title}
                 />
               </Link>
             </div>

--- a/src/templates/posts-list.jsx
+++ b/src/templates/posts-list.jsx
@@ -28,7 +28,15 @@ const PostsListTemplate = ({ data, pageContext }) => {
                 to={`/blog/${node.frontmatter.slug}`}
               >
                 <div>
-                  <div>{node.frontmatter.excerpt}</div>
+                  <div className={styles.listItemTitle}>
+                    {node.frontmatter.title}
+                  </div>
+                  {node.frontmatter.excerpt?.trim() !==
+                    node.frontmatter.title?.trim() && (
+                    <div className={styles.listItemDescription}>
+                      {node.frontmatter.excerpt}
+                    </div>
+                  )}
                   <div className={styles.listItemRight}>
                     <div className={styles.listItemDate}>
                       {formatDate(node.frontmatter.date)}
@@ -40,7 +48,7 @@ const PostsListTemplate = ({ data, pageContext }) => {
                 </div>
                 <GatsbyImage
                   image={getImage(node.frontmatter.preview_image)}
-                  alt={node.frontmatter.excerpt}
+                  alt={node.frontmatter.title}
                 />
               </Link>
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Home (`src/pages/index.js`) and `/posts/` (`src/templates/posts-list.jsx`) render only `frontmatter.excerpt` as the card headline. For "Looking around is enough", the card shows the web-beacon excerpt instead of the title, so the index looks wrong and does not match the post.

## Solution

In both short-post card lists, show:

1. `frontmatter.title` as the headline (`styles.listItemTitle`)
2. `frontmatter.excerpt` as a blurb (`styles.listItemDescription`) only when `excerpt.trim() !== title.trim()`, so Fowler-style posts where excerpt equals title do not duplicate
3. Image `alt={node.frontmatter.title}` instead of excerpt

Date / "more..." layout is unchanged. Article cards are unchanged.

## Details

- Home recent-posts list and `/posts/` paginated list now share the same title-plus-optional-blurb structure.
- No robots.txt or `site-content` submodule changes.

Verify: https://anth.us/ Looking around is enough card shows the title plus beacon blurb.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca0861e1-7d7c-43ca-808d-684b81426b84?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca0861e1-7d7c-43ca-808d-684b81426b84&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

