### PR TITLE
Fix homepage/posts list hydration flicker (mixed page-data + date formatting)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,9 +37,7 @@ jobs:
     - name: Restore Gatsby cache
       uses: actions/cache@v4
       with:
-        path: |
-          .cache
-          public
+        path: .cache
         key: gatsby-site-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ github.sha }}
         restore-keys: |
           gatsby-site-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-
@@ -47,6 +45,11 @@ jobs:
 
     - name: Install dependencies
       run: npm ci
+
+    # Never restore or reuse public/: stale page-data/sq/d/*.json from a prior
+    # build can disagree with freshly generated HTML and wipe posts on hydrate.
+    - name: Clean public output
+      run: rm -rf public
 
     - name: Build Gatsby site
       run: npm run build
@@ -57,9 +60,7 @@ jobs:
       if: always()
       uses: actions/cache@v4
       with:
-        path: |
-          .cache
-          public
+        path: .cache
         key: gatsby-site-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ github.sha }}
 
     - name: Configure AWS credentials via OIDC

--- a/src/components/blog-image.jsx
+++ b/src/components/blog-image.jsx
@@ -11,7 +11,7 @@ const BlogImage = ({ images, name, className, alt }) => {
         nodes {
           relativePath
           childImageSharp {
-            gatsbyImageData
+            gatsbyImageData(placeholder: NONE)
           }
         }
       }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,6 +6,7 @@ import Layout from "../components/layout"
 import Seo from "../components/seo"
 import Hero from "../components/hero"
 import * as styles from "../components/index.module.css"
+import { formatPostDate } from "../utils/format-post-date"
 
 // const utmParameters = `?utm_source=anthus&utm_medium=footer`
 const contactUrl =
@@ -434,7 +435,7 @@ const IndexPage = () => {
                   )}
                   <div className={styles.listItemRight}>
                     <div className={styles.listItemDate}>
-                      {formatDate(node.frontmatter.date)}
+                      {formatPostDate(node.frontmatter.date)}
                     </div>
                     <div>
                       <i>more...</i>
@@ -473,8 +474,3 @@ export const Head = () => {
 }
 
 export default IndexPage
-
-const formatDate = dateString => {
-  const options = { year: "numeric", month: "long", day: "numeric" }
-  return new Date(dateString).toLocaleDateString(undefined, options)
-}

--- a/src/templates/blog-post.jsx
+++ b/src/templates/blog-post.jsx
@@ -12,6 +12,7 @@ import {
   CitationsList,
 } from "gatsby-citation-manager"
 import MDXCode from "../components/MDXCode"
+import { formatPostDate } from "../utils/format-post-date"
 
 // Define the shortcodes object
 const shortcodes = { BlogImage, Citation, CitationsList, MDXCode, AudioNative }
@@ -31,7 +32,7 @@ const BlogPostTemplate = ({ data, children }) => {
           )}
           <div className="heading">
             <h1>{post.frontmatter.title}</h1>
-            <div className="date">{formatDate(post.frontmatter.date)}</div>
+            <div className="date">{formatPostDate(post.frontmatter.date)}</div>
             {post.frontmatter.authors &&
               post.frontmatter.authors.length > 0 && (
                 <div className="authors">
@@ -154,8 +155,3 @@ export const pageQuery = graphql`
 `
 
 export default BlogPostTemplate
-
-const formatDate = dateString => {
-  const options = { year: "numeric", month: "long", day: "numeric" }
-  return new Date(dateString).toLocaleDateString(undefined, options)
-}

--- a/src/templates/blog.jsx
+++ b/src/templates/blog.jsx
@@ -3,6 +3,7 @@ import { graphql, Link } from "gatsby"
 import Layout from "../components/layout"
 import Seo from "../components/seo"
 import { GatsbyImage, getImage } from "gatsby-plugin-image"
+import { formatPostDate } from "../utils/format-post-date"
 
 const CollectionTemplate = ({ data }) => {
   const publishedPosts = data.publishedPosts.edges
@@ -27,7 +28,7 @@ const CollectionTemplate = ({ data }) => {
                       <h3>{node.frontmatter.title}</h3>
                     </Link>
                     <div className="date">
-                      {formatDate(node.frontmatter.date)}
+                      {formatPostDate(node.frontmatter.date)}
                     </div>
                     <p
                       dangerouslySetInnerHTML={{
@@ -141,8 +142,3 @@ export const Head = () => {
 }
 
 export default CollectionTemplate
-
-const formatDate = dateString => {
-  const options = { year: "numeric", month: "long", day: "numeric" }
-  return new Date(dateString).toLocaleDateString(undefined, options)
-}

--- a/src/templates/posts-list.jsx
+++ b/src/templates/posts-list.jsx
@@ -5,6 +5,7 @@ import { GatsbyImage, getImage } from "gatsby-plugin-image"
 import Layout from "../components/layout"
 import Seo from "../components/seo"
 import * as styles from "../components/index.module.css"
+import { formatPostDate } from "../utils/format-post-date"
 
 const PostsListTemplate = ({ data, pageContext }) => {
   const { currentPage, numPages } = pageContext
@@ -39,7 +40,7 @@ const PostsListTemplate = ({ data, pageContext }) => {
                   )}
                   <div className={styles.listItemRight}>
                     <div className={styles.listItemDate}>
-                      {formatDate(node.frontmatter.date)}
+                      {formatPostDate(node.frontmatter.date)}
                     </div>
                     <div>
                       <i>more...</i>
@@ -138,8 +139,3 @@ export const Head = ({ pageContext }) => {
 }
 
 export default PostsListTemplate
-
-const formatDate = dateString => {
-  const options = { year: "numeric", month: "long", day: "numeric" }
-  return new Date(dateString).toLocaleDateString(undefined, options)
-}

--- a/src/utils/format-post-date.js
+++ b/src/utils/format-post-date.js
@@ -1,0 +1,19 @@
+import { format, isValid, parseISO } from "date-fns"
+
+/**
+ * Format a post frontmatter date for display. SSR- and hydration-safe:
+ * - Date-only strings (YYYY-MM-DD) are parsed as local calendar dates, not UTC
+ *   midnight (which shifts the day in US timezones and mismatches SSR vs client).
+ * - Uses date-fns with a fixed pattern instead of toLocaleDateString(undefined),
+ *   which varies by browser locale and caused React hydration errors #418/#423/#425.
+ */
+export function formatPostDate(dateString) {
+  if (!dateString) return ""
+
+  const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString)
+  const date = dateOnlyMatch
+    ? new Date(+dateOnlyMatch[1], +dateOnlyMatch[2] - 1, +dateOnlyMatch[3])
+    : parseISO(dateString)
+
+  return isValid(date) ? format(date, "MMMM d, yyyy") : String(dateString)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On `/` and `/posts/`, newly published posts briefly appear after reload, then disappear ~1s later when React hydrates. DevTools shows React minified errors **#418**, **#423**, and **#425** (hydration mismatch / failed hydration).

Production also showed **mixed deploy timestamps** on the same page load — e.g. `/page-data/sq/d/1224204943.json` last-modified ~20:56Z while HTML and other assets were ~21:16Z.

## Root cause

Two independent issues combined to produce the symptom:

### 1. Mixed Gatsby artifacts from CI `public/` cache (primary — posts vanish)

The **site** deploy workflow (`.github/workflows/deploy.yml`) restored **both** `.cache` and `public/` from GitHub Actions cache before `gatsby build`.

Gatsby static-query hashes are derived from the **query text**, not query results. When content changes (new posts) but the homepage `useStaticQuery` string is unchanged, the hash stays `1224204943`.

On an incremental build with a restored `public/`:

- Gatsby regenerates SSR HTML with the **new** post list
- Stale `public/page-data/sq/d/1224204943.json` from a prior build can survive (or be served from S3 alongside fresh HTML after overlapping deploys)

At hydration, the client loads the **stale** static-query JSON / webpack payload while the SSR HTML already rendered the new posts. React detects the mismatch, throws #418/#423/#425, and reconciles to the stale client data — **posts disappear**.

The **content** deploy workflow already avoided this: it caches only `.cache` and runs `rm -rf public` before build. The site workflow did not.

`gatsby-plugin-offline` / service workers are **not** involved (not installed).

### 2. Locale/timezone date formatting (secondary — hydration errors on dates)

`formatDate` used `new Date(dateString).toLocaleDateString(undefined, options)` in homepage recent posts, `/posts/`, `/blog/`, and blog permalinks.

- `undefined` locale → browser-dependent formatting at hydration time
- Date-only strings like `"2025-01-21"` parse as **UTC midnight**, shifting the calendar day in US timezones vs Node SSR (UTC in CI)

This produces text mismatches and contributes to hydration failures even when the post list length matches.

## Fix

| Area | Change |
|------|--------|
| **Deploy** | Site workflow caches **only** `.cache`; **`rm -rf public`** before every build (aligned with content repo workflow) |
| **Dates** | New `src/utils/format-post-date.js` — parses `YYYY-MM-DD` as local calendar date, formats with fixed `date-fns` pattern; used in index, posts-list, blog, blog-post templates |
| **BlogImage** | `gatsbyImageData(placeholder: NONE)` so post permalink images don't ship `opacity: 0` until JS loads |

## Verification

- `npm run build` succeeds locally
- `formatPostDate('2025-01-21')` → `January 21, 2025` consistently (no timezone shift)

## Follow-ups (not in this PR)

- Site deploy still uses the **committed submodule SHA**; a content-only deploy can be overwritten by a later site deploy with a stale pointer. Consider auto-bumping the submodule on content push or consolidating to a single deploy path.
- List thumbnail `GatsbyImage` on homepage/posts still use global `placeholder: 'blurred'` fade-in (cosmetic, not hydration-related).

## Files changed

- `.github/workflows/deploy.yml`
- `src/utils/format-post-date.js` (new)
- `src/pages/index.js`
- `src/templates/posts-list.jsx`
- `src/templates/blog.jsx`
- `src/templates/blog-post.jsx`
- `src/components/blog-image.jsx`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18f06390-20c8-4d2d-8674-52de666ba555?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18f06390-20c8-4d2d-8674-52de666ba555&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

