### PR TITLE
Fix homepage Recent Articles external_url links + never-use-fast interconnect

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -70,6 +70,7 @@ const IndexPage = () => {
               date
               slug
               excerpt
+              external_url
               state
               preview_image {
                 childImageSharp {
@@ -388,17 +389,28 @@ const IndexPage = () => {
       <ul className="blog">
         {data.recentArticles.edges.map(({ node }) => {
           const previewImage = getImage(node.frontmatter.preview_image)
+          const { external_url, slug, title } = node.frontmatter
+          const cardLink = external_url
+            ? { href: external_url, isExternal: true }
+            : { href: `/blog/${slug}`, isExternal: false }
+          const cardMedia = (
+            <>
+              <GatsbyImage
+                image={previewImage}
+                alt={title}
+                className="right"
+              />
+              <h3>{title}</h3>
+            </>
+          )
           return (
             <div className="blog-post-preview" key={node.id}>
               <li className="clear-float">
-                <Link to={`/blog/` + node.frontmatter.slug}>
-                  <GatsbyImage
-                    image={previewImage}
-                    alt={node.frontmatter.title}
-                    className="right"
-                  />
-                  <h3>{node.frontmatter.title}</h3>
-                </Link>
+                {cardLink.isExternal ? (
+                  <a href={cardLink.href}>{cardMedia}</a>
+                ) : (
+                  <Link to={cardLink.href}>{cardMedia}</Link>
+                )}
                 <div className="date">{node.frontmatter.date}</div>
                 <div
                   dangerouslySetInnerHTML={{ __html: node.frontmatter.excerpt }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Publicist-approved Anth.us interconnect fixes:

### Fix 1 — Homepage Recent Articles dead cards

Recent Articles on the homepage always linked to `/blog/{slug}`. Platform items with `external_url` frontmatter (Chatticus, Antharchy) therefore pointed at dead `/blog/` paths that return 403.

**Change:** When `frontmatter.external_url` is set, Recent Articles cards render an absolute `<a href>` instead of a Gatsby `<Link>` to `/blog/{slug}`.

### Fix 2 — never-use-fast ↔ Chatticus interconnect

Bumps `anthus-site-content` to `d576c07` with a natural in-body link from `never-use-fast` to https://chattic.us/thoughts/own-the-defaults/ in the defaults section.

## Files changed

- `src/pages/index.js` — honor `external_url` in Recent Articles cards
- `src/site-content` submodule pin (`e465f13` → `d576c07`)

## Verification

- Chatticus card should link to `https://chattic.us`
- Antharchy card should link to `https://github.com/AnthusAI/Antharchy`
- `never-use-fast` article includes Chatticus own-the-defaults link

## Related

Content branch pushed: `cursor/never-use-fast-chatticus-link-0b4b` on [anthus-site-content](https://github.com/AnthusAI/anthus-site-content/compare/main...cursor/never-use-fast-chatticus-link-0b4b?expand=1). Open that compare link to create the companion content PR (this agent token cannot open PRs on the content repo).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f275eea0-3aa0-4401-8123-7156703c0b4b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f275eea0-3aa0-4401-8123-7156703c0b4b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

